### PR TITLE
Fixed random-connect and fastest-connect commands.

### DIFF
--- a/ProtonVPN.py
+++ b/ProtonVPN.py
@@ -98,10 +98,10 @@ class Handler():
 		#subprocess.Popen.kill()
 
 	def fastestServerBtn(self, button):
-		subprocess.Popen(["protonvpn-cli", "--fastest-connect"])
+		subprocess.Popen(["protonvpn-cli", "-fastest-connect"])
 
 	def randomServerBtn(self, button):
-		subprocess.Popen(["protonvpn-cli", "--random-connect"])
+		subprocess.Popen(["protonvpn-cli", "-random-connect"])
 
 # Connect glade GUI
 builder = Gtk.Builder()


### PR DESCRIPTION
Updated the Random and Fastest connect buttons to execute the correct protonvpn-cli command (-random-connect) as opposed to --random-connect.

Note: Could be an issue on my end where the --random-connect and --fastest-connect are unrecognised as commands.