### PR TITLE
Added Basic Dependency Checks

### DIFF
--- a/ProtonVPN.py
+++ b/ProtonVPN.py
@@ -5,13 +5,11 @@ import subprocess
 from threading import Thread
 import socket
 import time
-import requests
-import json
 from ConfigParser import SafeConfigParser
 from serverList import serverList
 import os
 import sys
-import schedule
+
 
 # OpenVPN Gateway IP Address for connection status
 remoteServer = "10.8.8.1"
@@ -20,8 +18,40 @@ remoteServer = "10.8.8.1"
 if not os.geteuid() == 0:
     sys.exit("Root access is required to use ProtonVPN-Gtk...")
 
+missingDependencies = False
+modulesRequired = ""
+
+try:
+    subprocess.check_output(['which', 'protonvpn-cli'])
+except subprocess.CalledProcessError, e:
+    modulesRequired += "protonvpn-cli needs to be installed.\n"
+    missingDependencies = True
+
+try:
+    import schedule
+except ImportError:
+    missingDependencies = True
+    modulesRequired += "python-schedule needs to be installed.\n"
+
+try:
+    import requests
+except ImportError:
+    missingDependencies = True
+    modulesRequired += "python-requests needs to be installed.\n"
+
+try:
+    import json
+except ImportError:
+    missingDependencies = True
+    modulesRequired += "python-json needs to be installed.\n"
+
+if(missingDependencies):
+    sys.exit(modulesRequired)
+
 # Setup GUI Handlers
 class Handler():
+
+
 
 	def __init__(self):
 		# Connect GUI components

--- a/ProtonVPN.py
+++ b/ProtonVPN.py
@@ -18,33 +18,40 @@ remoteServer = "10.8.8.1"
 if not os.geteuid() == 0:
     sys.exit("Root access is required to use ProtonVPN-Gtk...")
 
+
+
 missingDependencies = False
 modulesRequired = ""
 
+# Checks that protonvpn-cli is installed
 try:
     subprocess.check_output(['which', 'protonvpn-cli'])
 except subprocess.CalledProcessError, e:
     modulesRequired += "protonvpn-cli needs to be installed.\n"
     missingDependencies = True
 
+# Checks for the python-schedule module
 try:
     import schedule
 except ImportError:
     missingDependencies = True
     modulesRequired += "python-schedule needs to be installed.\n"
 
+# Checks for the python-requests module
 try:
     import requests
 except ImportError:
     missingDependencies = True
     modulesRequired += "python-requests needs to be installed.\n"
 
+# Checks for the python-json module	
 try:
     import json
 except ImportError:
     missingDependencies = True
     modulesRequired += "python-json needs to be installed.\n"
 
+# Exits ProtonVPN.py execution with missing dependencies
 if(missingDependencies):
     sys.exit(modulesRequired)
 

--- a/config.ini
+++ b/config.ini
@@ -1,4 +1,4 @@
 [globalVars]
-lastconnection = SE#8
+lastconnection = SE#7
 protocol = udp
 


### PR DESCRIPTION
I have introduced some very basic checks for dependencies. The code leaves out the check for python (it is assumed they have python if they are able to actually run the script) and I have left out Gnome checks as I am not 100% on the best method to determine the version.

gnome-shell --version could be used and have the output checked for version number.